### PR TITLE
Cancel by exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+*.json
+
+# configuration files
+*.yaml
+
 # C extensions
 *.so
 
@@ -75,6 +80,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+**/*.ipynb
 
 # IPython
 profile_default/

--- a/connectors/paradex_perp.py
+++ b/connectors/paradex_perp.py
@@ -168,11 +168,7 @@ class ParadexPerpConnector(ConnectorBase):
             else:
                 oid = exchange_order_id 
         try:
-<<<<<<< HEAD
-            self.rate_limited_request(self.paradex.api_client.cancel_order_by_client_id, client_order_id)
-=======
             resp = self.rate_limited_request(cancel_method, oid)
->>>>>>> cancelByExchangeId
             self.active_orders[client_order_id].status = 'CANCELLING'
         except ValidationError as ve:
             if ve.data['message'] == 'rate limit exceeded':
@@ -375,16 +371,10 @@ class ParadexPerpConnector(ConnectorBase):
             return
 
         _market = _data['market']
-<<<<<<< HEAD
         _order = self.active_orders[_data['client_id']]
         if _order.exchange_order_id is None:
             _order.exchange_order_id = _data['id']
 
-=======
-        exchange_order_id = _data.get('id',None)
-        if exchange_order_id is not None:
-            self.active_orders[_data['client_id']].exchange_order_id = exchange_order_id
->>>>>>> cancelByExchangeId
         if _data['status'] == 'NEW':
             self.active_orders[_data['client_id']].status = 'NEW'
             if _market in self._trade_callbacks:

--- a/utils/misc_utils.py
+++ b/utils/misc_utils.py
@@ -3,6 +3,7 @@ This module provides utility functions for various purposes.
 """
 
 import ruamel.yaml
+from ruamel.yaml import YAML
 
 
 def load_config(file_path: str, raise_error: bool=True) -> dict:
@@ -18,7 +19,8 @@ def load_config(file_path: str, raise_error: bool=True) -> dict:
     """
     try:
         with open(file_path, 'r') as file:
-            return ruamel.yaml.safe_load(file)
+            # return ruamel.yaml.safe_load(file)
+            return YAML(typ='safe',pure=True).load(file)
     except Exception as e:
         if raise_error:
             raise e


### PR DESCRIPTION
- merged with rate limit blocking (due to 'rate limit exceeded' exception as ValidationError)
- added PARAM_CANCEL_BY_EXCHANGE_ORDER_ID : default True, if set to False, will use [DELETE /orders/by_client_id/{client_id}]
- added PARAM_ORDER_RATIO_TO_CANCEL_ALL : default 0.5, if number of orders to cancel / number of active orders > this value, will use [DELETE /orders]